### PR TITLE
Invite_Friend_and_always_https

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script
+      src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.8/kakao.min.js"
+      integrity="sha384-WUSirVbD0ASvo37f3qQZuDap8wy76aJjmGyXKOYgPL/NdAs8HhgmPlk9dz2XQsNv"
+      crossorigin="anonymous"
+    ></script>
     <title>여담:여행을 담다</title>
   </head>
   <body>

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,4 @@ if (window.Kakao && !window.Kakao.isInitialized()) {
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,11 @@ import './index.css';
 import './styles/tailwind.css';
 import App from './App';
 
+// Kakao SDK 초기화
+if (window.Kakao && !window.Kakao.isInitialized()) {
+  window.Kakao.init('3b520efdd3c0917f27e809b99ab17c32');
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>

--- a/src/pages/Plan/PlanInvitePage.jsx
+++ b/src/pages/Plan/PlanInvitePage.jsx
@@ -42,10 +42,12 @@ const PlanInvitePage = () => {
   // 절대 URL 보장 (카카오 템플릿 이미지는 https 접근 가능해야 함)
   const toAbsUrl = (pathOrUrl) => {
     if (!pathOrUrl) return '';
-    if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
-    // 예: 'assets/logo.png' 또는 '/assets/logo.png'
-    const p = pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`;
-    return `${window.location.origin}${p}`;
+    let url = String(pathOrUrl).trim();
+    // 어떤 절대 URL이 와도 http는 https로 강제
+    url = url.replace(/^http:\/\//i, 'https://');
+    if (/^https:\/\//i.test(url)) return url;
+    const p = url.startsWith('/') ? url : `/${url}`;
+    return `${window.location.origin}${p}`.replace(/^http:\/\//i, 'https://');
   };
 
   // 본인 제외 멤버

--- a/src/pages/Plan/PlanInvitePage.jsx
+++ b/src/pages/Plan/PlanInvitePage.jsx
@@ -160,10 +160,11 @@ const PlanInvitePage = () => {
   const handleCopyLink = async () => {
     try {
       setBusy(true);
-      const { gid, gname } = await ensureGroupReady(); // ← 구조분해!
+      const { gid, gname } = await ensureGroupReady();
       const url = makeInviteUrl(gid, gname);
+
       await navigator.clipboard.writeText(url);
-      message.success('초대 링크가 복사되었습니다!');
+      message.success('초대 링크가 복사되었습니다! 카카오톡에 붙여넣어보세요.');
     } catch (e) {
       console.error(e);
       message.error('초대 링크 복사에 실패했어요.');
@@ -184,15 +185,21 @@ const PlanInvitePage = () => {
           import.meta?.env?.VITE_KAKAO_TEMPLATE_ID
       );
       if (!TEMPLATE_ID) throw new Error('KAKAO_TEMPLATE_ID 누락');
-      // ① 제목
-      const planTitle = groupName || '여행 플랜';
-      // ② 날짜 구간: planStore의 startDate/endDate 사용
-      const { startDate, endDate } = usePlanStore.getState();
+      // ① 제목,  ② 날짜 구간: planStore의 startDate/endDate 사용
+      // ✅ 선택 지역명이 있으면 "OO 여행"
+      const { selectedRegionName, selectedRegionImage, startDate, endDate } =
+        usePlanStore.getState();
+      const planTitle = selectedRegionName
+        ? `${selectedRegionName} 여행`
+        : groupName || '여행 플랜';
       const dateRange =
         startDate && endDate ? `${fmt(startDate)} - ${fmt(endDate)}` : '';
       // ③ 썸네일: 커버 이미지가 있으면 사용, 없으면 앱 로고로 대체
-      const coverImage = usePlanStore.getState()?.coverImage; // 있으면 쓰고
-      const thumb = coverImage
+      // ✅ 선택 지역 이미지가 우선, 없으면 기존 coverImage → 앱 로고
+      const coverImage = usePlanStore.getState()?.coverImage;
+      const thumb = selectedRegionImage
+        ? toAbsUrl(selectedRegionImage)
+        : coverImage
         ? toAbsUrl(coverImage)
         : toAbsUrl('assets/logo.png');
 

--- a/src/pages/Plan/PlanLocationPage.jsx
+++ b/src/pages/Plan/PlanLocationPage.jsx
@@ -20,9 +20,7 @@ const normalizeImageUrl = (raw) => {
     .replace(/^"(.*)"$/, '$1');
   if (/^data:/.test(src)) return src;
   if (/^https?:\/\//i.test(src)) {
-    return window.location.protocol === 'https:'
-      ? src.replace(/^http:\/\//i, 'https://')
-      : src;
+    return src.replace(/^http:\/\//i, 'https://');
   }
   const base = http?.defaults?.baseURL || window.location.origin;
   const baseUrl = new URL(base, window.location.origin);
@@ -32,7 +30,9 @@ const normalizeImageUrl = (raw) => {
       url = url.replace(/^http:\/\//i, 'https://');
     return url;
   }
-  return new URL(src, baseUrl.href).toString();
+  return new URL(src, baseUrl.href)
+    .toString()
+    .replace(/^http:\/\//i, 'https://');
 };
 
 const PlanLocationPage = () => {

--- a/src/pages/Plan/PlanLocationPage.jsx
+++ b/src/pages/Plan/PlanLocationPage.jsx
@@ -38,6 +38,7 @@ const normalizeImageUrl = (raw) => {
 const PlanLocationPage = () => {
   const navigate = useNavigate();
   const { setLocationIds, setLocationCodes } = usePlanStore();
+  const setSelectedRegionMeta = usePlanStore((s) => s.setSelectedRegionMeta);
 
   const [searchText, setSearchText] = useState('');
   const [locations, setLocations] = useState([]);
@@ -132,6 +133,7 @@ const PlanLocationPage = () => {
       ),
     });
     setLocationCodes([canon(selected)]);
+    setSelectedRegionMeta({ name: selected.name, imageUrl: selected.imageUrl });
     navigate('/plan/date');
   };
 

--- a/src/store/planStore.js
+++ b/src/store/planStore.js
@@ -22,6 +22,10 @@ const usePlanStore = create(
       people: 1,
       budget: 0,
 
+      // 선택 지역 메타
+      selectedRegionName: '',
+      selectedRegionImage: '',
+
       // (구) planStore.cartItems — 호환을 위해 남겨두지만 실제로는 cartStore 사용
       cartItems: [],
 
@@ -99,6 +103,12 @@ const usePlanStore = create(
       setScheduleType: (v) => set({ scheduleType: v }),
       setScheduleStyle: (v) => set({ scheduleStyle: v }),
 
+      setSelectedRegionMeta: ({ name, imageUrl }) =>
+        set({
+          selectedRegionName: String(name || ''),
+          selectedRegionImage: String(imageUrl || ''),
+        }),
+
       // ✅ 라우트 경계에서 호출: /plan/* 들어옴
       beginPlanFlow: () => set({ inPlanFlow: true, planSessionId: Date.now() }),
 
@@ -128,6 +138,8 @@ const usePlanStore = create(
           groupName: '',
           scheduleType: 'GROUP',
           scheduleStyle: '',
+          selectedRegionName: '',
+          selectedRegionImage: '',
           // favorites 유지
         });
       },
@@ -159,6 +171,8 @@ const usePlanStore = create(
           groupName: '',
           scheduleType: 'GROUP',
           scheduleStyle: '',
+          selectedRegionName: state.selectedRegionName, // 지역은 유지하고 싶으면 그대로
+          selectedRegionImage: state.selectedRegionImage,
           // favorites는 그대로 둠
         }));
       },
@@ -189,6 +203,8 @@ const usePlanStore = create(
           scheduleType: 'GROUP',
           scheduleStyle: '',
           favorites: [],
+          selectedRegionName: '',
+          selectedRegionImage: '',
         });
         try {
           sessionStorage.removeItem('plan-store-v2');
@@ -284,6 +300,8 @@ const usePlanStore = create(
           scheduleType: 'GROUP',
           scheduleStyle: '',
           favorites: [],
+          selectedRegionName: '',
+          selectedRegionImage: '',
         }),
 
       // ✅ 영구 저장(세션)까지 완전 삭제 — 로그아웃 등에서 호출
@@ -310,6 +328,8 @@ const usePlanStore = create(
           scheduleType: 'GROUP',
           scheduleStyle: '',
           favorites: [],
+          selectedRegionName: '',
+          selectedRegionImage: '',
         });
         try {
           sessionStorage.removeItem('plan-store-v2');
@@ -344,6 +364,8 @@ const usePlanStore = create(
         scheduleType: s.scheduleType,
         scheduleStyle: s.scheduleStyle,
         favorites: s.favorites,
+        selectedRegionName: s.selectedRegionName,
+        selectedRegionImage: s.selectedRegionImage,
       }),
 
       // 과거 키 마이그레이션

--- a/src/utils/kakao.js
+++ b/src/utils/kakao.js
@@ -1,50 +1,28 @@
-// CRA 전용: Vite 아님
-const KAKAO_JS_KEY = process.env.REACT_APP_KAKAO_JS_KEY || '';
-
+// src/utils/kakao.js
 let kakaoReady;
-export function loadKakao() {
-  if (kakaoReady) return kakaoReady;
 
-  kakaoReady = new Promise((resolve, reject) => {
-    // 이미 초기화된 경우
-    if (window.Kakao && window.Kakao.isInitialized && window.Kakao.isInitialized()) {
-      return resolve(window.Kakao);
-    }
+export async function loadKakao() {
+  if (window.Kakao && window.Kakao.isInitialized?.()) return window.Kakao;
 
-    // 이미 스크립트가 있으면 로드 이벤트만 대기
-    const SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js';
-    const exist = document.querySelector(`script[src="${SDK_URL}"]`);
-    const onReady = () => {
-      try {
-        if (!window.Kakao) throw new Error('Kakao SDK not found');
-        if (!window.Kakao.isInitialized || !window.Kakao.isInitialized()) {
-          if (!KAKAO_JS_KEY) throw new Error('Kakao JS key is missing');
-          window.Kakao.init(KAKAO_JS_KEY);
-        }
-        resolve(window.Kakao);
-      } catch (e) {
-        reject(e);
-      }
-    };
-
-    if (exist) {
-      if (window.Kakao && window.Kakao.isInitialized && window.Kakao.isInitialized()) {
-        return resolve(window.Kakao);
-      }
-      exist.addEventListener('load', onReady, { once: true });
-      exist.addEventListener('error', reject, { once: true });
-      return;
-    }
-
-    // 스크립트 최초 로딩
+  // SDK 스크립트 주입
+  if (!document.getElementById('kakao-js-sdk')) {
     const s = document.createElement('script');
-    s.src = SDK_URL;
-    s.async = true;
+    s.id = 'kakao-js-sdk';
+    s.src = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js';
     s.crossOrigin = 'anonymous';
-    s.onload = onReady;
-    s.onerror = reject;
     document.head.appendChild(s);
-  });
+    kakaoReady = new Promise((res) => (s.onload = res));
+  }
 
-  return kakaoReady;
+  if (kakaoReady) await kakaoReady;
+
+  const JS_KEY =
+    process.env.REACT_APP_KAKAO_JS_KEY || import.meta?.env?.VITE_KAKAO_JS_KEY; // (Vite 겸용)
+
+  if (!JS_KEY) throw new Error('REACT_APP_KAKAO_JS_KEY 누락');
+
+  if (!window.Kakao.isInitialized()) {
+    window.Kakao.init(JS_KEY); // 반드시 JavaScript 키
+  }
+  return window.Kakao;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "upgrade-insecure-requests"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 📌 PR 제목 예시
feat: 친구 초대 기능 추가, 항상  https로 연결

---

## ✨ 변경 사항
- 친구 초대 기능 카카오 템플릿 만듦, 아직 실제로 초대는 안되는 듯
- https로 항상 연결하도록 설정 추가
---

## 🧪 테스트 방법
1. 컴퓨터로 테스트 할 때는 모바일 에뮬레이터 끄고 테스트 진행해야 초대가 가능함


---

## 🔍 관련 이슈

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
