### PR TITLE
[Doheun/Feat]: 장바구니에서 즐겨찾기 API 연동

### DIFF
--- a/src/pages/Plan/PlanCartPage.jsx
+++ b/src/pages/Plan/PlanCartPage.jsx
@@ -19,6 +19,7 @@ import usePlanStore from '../../store/planStore';
 import { loadKakaoMap } from '../../utils/kakaoMapLoader';
 import { getPlacesByRegionTheme, getRegions } from '../../api';
 import useCartStore from '../../store/cartStore';
+import { toggleFavorite as toggleFavoriteApi } from '../../api/favorite/toggleFavorite';
 
 const CATEGORIES = ['관광', '숙소', '맛집', '축제', '레저'];
 const CATEGORY_TO_CONTENTTYPEID = {
@@ -656,6 +657,20 @@ const PlanCartPage = () => {
                 !!item?.location &&
                 typeof item.location.lat === 'number' &&
                 typeof item.location.lng === 'number';
+                const handleFavorite = async () => {
+                  try {
+                    const res = await toggleFavoriteApi(String(item.contentId));
+                    if (res.favorite) {
+                      message.success('즐겨찾기에 추가되었습니다!');
+                    } else {
+                      message.info('즐겨찾기에서 제거되었습니다.');
+                    }
+                    toggleFavorite(String(item.contentId));
+                  } catch (err) {
+                    console.error('[favorite error]', err);
+                    message.error('즐겨찾기 처리에 실패했습니다.');
+                  }
+                };
 
               return (
                 <div
@@ -691,9 +706,7 @@ const PlanCartPage = () => {
                       )}
                       <FavoriteButton
                         isActive={isFavorite(String(item.contentId))}
-                        toggleFavorite={() =>
-                          toggleFavorite(String(item.contentId))
-                        }
+                        toggleFavorite={handleFavorite}
                       />
                     </div>
                     <div>


### PR DESCRIPTION
## 📌 PR 제목 예시
feat: 새로운 기능 개발
fix: 버그 수정
refactor: 리팩토링 (기능 변경 없음)
style: 스타일 (UI, CSS 등)
docs: 문서 변경
test: 테스트 코드 추가
chore: 설정, 빌드 수정 등 기타 작업

---

## ✨ 변경 사항
- 일정짜기-장바구니 과정에서 즐겨찾기된 장소는 빨간 하트, 아닌 곳은 빈 하트
- message로 즐겨찾기 등록/제거 알림
- 마이페이지 즐겨찾기에서 확인 가능

---

## 🧪 테스트 방법
1.

---

## 🔍 관련 이슈
- closes 

---

## 📝 체크리스트 ✓ 사용해서 표시
- [ ] 동작 테스트 완료
- [ ] 코드 컨벤션 준수
- [ ] 주석, 콘솔 제거
- [ ] 팀원과 사전 공유 완료
